### PR TITLE
Rename runtime-rxjs package to client-core

### DIFF
--- a/CopilotKit/packages/client-core/README.md
+++ b/CopilotKit/packages/client-core/README.md
@@ -1,0 +1,7 @@
+# @copilotkit/client-core
+
+A lightweight RxJS based client service for CopilotKit.
+
+This package wraps `@copilotkit/runtime-client-gql` and exposes reactive streams
+for messages and loading state. It can be consumed by any framework that
+supports RxJS.

--- a/CopilotKit/packages/client-core/package.json
+++ b/CopilotKit/packages/client-core/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@copilotkit/client-core",
+  "private": false,
+  "homepage": "https://github.com/CopilotKit/CopilotKit",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "1.0.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch --no-splitting",
+    "test": "jest --passWithNoTests",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next"
+  },
+  "dependencies": {
+    "rxjs": "^7.8.1",
+    "@copilotkit/runtime-client-gql": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^6.7.0",
+    "typescript": "^5.2.3",
+    "tsconfig": "workspace:*",
+    "eslint": "^8.56.0",
+    "eslint-config-custom": "workspace:*",
+    "@types/node": "^18.11.17",
+    "jest": "^29.6.4",
+    "ts-jest": "^29.1.1"
+  }
+}

--- a/CopilotKit/packages/client-core/src/CopilotRuntimeService.ts
+++ b/CopilotKit/packages/client-core/src/CopilotRuntimeService.ts
@@ -1,0 +1,87 @@
+import { BehaviorSubject } from "rxjs";
+import {
+  CopilotRuntimeClient,
+  CopilotRuntimeClientOptions,
+  Message,
+  convertMessagesToGqlInput,
+  convertGqlOutputToMessages,
+  filterAdjacentAgentStateMessages,
+} from "@copilotkit/runtime-client-gql";
+
+export interface CopilotRuntimeServiceOptions extends CopilotRuntimeClientOptions {
+  /** Initial messages for the chat */
+  initialMessages?: Message[];
+}
+
+export class CopilotRuntimeService {
+  private runtime: CopilotRuntimeClient;
+  private abortController: AbortController | null = null;
+
+  private messagesSubject: BehaviorSubject<Message[]>;
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+
+  /** Observable stream of chat messages */
+  readonly messages$: ReturnType<BehaviorSubject<Message[]>['asObservable']>;
+  /** Observable loading state */
+  readonly loading$ = this.loadingSubject.asObservable();
+
+  constructor(options: CopilotRuntimeServiceOptions) {
+    this.runtime = new CopilotRuntimeClient(options);
+    this.messagesSubject = new BehaviorSubject<Message[]>(options.initialMessages ?? []);
+    this.messages$ = this.messagesSubject.asObservable();
+  }
+
+  /** Current messages value */
+  get messages(): Message[] {
+    return this.messagesSubject.getValue();
+  }
+
+  /** Append a message and optionally trigger a completion */
+  append(message: Message, followUp = true) {
+    this.messagesSubject.next([...this.messagesSubject.getValue(), message]);
+    if (followUp) {
+      void this.runCompletion();
+    }
+  }
+
+  /** Abort any in-flight request */
+  stop() {
+    this.abortController?.abort();
+  }
+
+  /** Execute chat completion using the runtime client */
+  async runCompletion(): Promise<Message[]> {
+    this.stop();
+    this.abortController = new AbortController();
+    const prev = this.messagesSubject.getValue();
+    this.loadingSubject.next(true);
+
+    const stream = this.runtime.asStream(
+      this.runtime.generateCopilotResponse({
+        data: { messages: convertMessagesToGqlInput(prev) },
+        signal: this.abortController.signal,
+      }),
+    );
+
+    const reader = stream.getReader();
+    const newMessages: Message[] = [];
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value?.generateCopilotResponse) continue;
+        const chunk = convertGqlOutputToMessages(
+          filterAdjacentAgentStateMessages(value.generateCopilotResponse.messages),
+        );
+        newMessages.push(...chunk);
+        this.messagesSubject.next([...prev, ...newMessages]);
+      }
+    } finally {
+      this.loadingSubject.next(false);
+      this.abortController = null;
+    }
+
+    return newMessages;
+  }
+}

--- a/CopilotKit/packages/client-core/src/index.ts
+++ b/CopilotKit/packages/client-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./CopilotRuntimeService";

--- a/CopilotKit/packages/client-core/tsconfig.json
+++ b/CopilotKit/packages/client-core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../utilities/tsconfig/base.json",
+  "include": ["."],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/*"
+  ]
+}

--- a/CopilotKit/packages/client-core/tsup.config.ts
+++ b/CopilotKit/packages/client-core/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, Options } from "tsup";
+
+export default defineConfig((options: Options) => ({
+  entry: ["src/**/*.{ts,tsx}"],
+  format: ["esm", "cjs"],
+  dts: true,
+  minify: false,
+  sourcemap: true,
+  exclude: ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/*"],
+  ...options,
+}));


### PR DESCRIPTION
## Summary
- adds `@copilotkit/client-core`
- keep service implementation exposing RxJS observables

## Testing
- `pnpm --filter @copilotkit/client-core build` *(fails: tsup not found)*
- `pnpm --filter @copilotkit/client-core test` *(fails: jest not found)*