### PR TITLE
Fix stop button to terminate LangGraph agent

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -745,6 +745,7 @@ export const useCopilotChatLogic = (
       });
     } else {
       defaultStopGeneration();
+      stopCurrentAgent();
     }
   }
   function reloadMessages(messageId: string) {


### PR DESCRIPTION
## Summary
- ensure stop button halts LangGraph agent execution

## Testing
- `pnpm -r --filter "./CopilotKit/packages/react-ui" test` *(fails: jest not found)*